### PR TITLE
Keep pip cache between Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+sudo: false  # Force container-based builds.
 language: python
 python:
   - "2.7"
   - "pypy"
+cache:
+  directories:
+    - $HOME/.cache/pip
 services:
   - elasticsearch
   - redis-server


### PR DESCRIPTION
This also adds `sudo: false` to prevent accidentally switching away from container-based builds.
