### PR TITLE
Add a paginated view of all comments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 molo.core<3.0.0,>=2.5.0
 molo.profiles<1.0.0,>=0.1.4
-molo.commenting<1.0.0,>=0.2.4
+molo.commenting<1.0.0,>=0.2.5
 django-extensions
 django-google-analytics-app
 django-celery

--- a/tuneme/static/css/styles.css
+++ b/tuneme/static/css/styles.css
@@ -161,7 +161,7 @@ label {font:normal 15px 'Quicksand', Arial, Helvetica, sans-serif;}
         .grey .article-copy blockquote, .comment.grey .by strong, .comment.grey .report {color:#828282;}
 
 
-
+.pagination {padding:15px; text-align: left}
 
 /* Footer */
 .footer {padding:15px; font-size:85%; clear:both; display:block;}

--- a/tuneme/templates/comments/comment.html
+++ b/tuneme/templates/comments/comment.html
@@ -1,5 +1,4 @@
 {% load i18n molo_commenting_tags %}
-<hr>
 <div class="comment {{self.get_parent_section.get_effective_extra_style_hints}} {% if node.user.is_staff %}staff{% endif %}">
   <p class="by"><strong>{{node.user_name}}</strong> <span class="date">{{node.submit_date|date:"j F Y"}}</span></p>
   {% if node.is_removed %}
@@ -9,3 +8,4 @@
     <p><a href="{% url 'molo-comments-report' node.pk %}?next={% url 'report_response' node.pk %}" class="report">{% trans "Report" %}</a></p>
   {% endif %}
 </div>
+<hr>

--- a/tuneme/templates/comments/comments.html
+++ b/tuneme/templates/comments/comments.html
@@ -1,0 +1,33 @@
+{% extends "core/_article_page.html" %}
+{% load wagtailcore_tags wagtailimages_tags comments mptt_tags molo_commenting_tags i18n %}
+
+{% block content %}
+<div class="title turq align-left">
+<h6>{% trans "Comments" %}</h6>
+</div>
+<div id="comments-list">
+      {% for node in comments %}
+        {% include "comments/comment.html" %}
+      {% endfor %}
+</div>
+
+<div class="pagination">
+    <span class="step-links">
+        {% if comments.has_previous %}
+            <a href="?p={{ comments.previous_page_number }}">&larr;</a>
+        {% endif %}
+        <span class="current">
+            Page {{ comments.number }} of {{ comments.paginator.num_pages }}
+        </span>
+        {% if comments.has_next %}
+            <a href="?p={{ comments.next_page_number }}">&rarr;</a>
+        {% endif %}
+    </span>
+    <br>
+    <br>
+    <a href="{% pageurl self %}">{% trans "Back to article" %}</a>
+</div>
+
+{# <hr>#}
+
+{% endblock %}

--- a/tuneme/templates/comments/comments.html
+++ b/tuneme/templates/comments/comments.html
@@ -28,6 +28,4 @@
     <a href="{% pageurl self %}">{% trans "Back to article" %}</a>
 </div>
 
-{# <hr>#}
-
 {% endblock %}

--- a/tuneme/templates/core/article_page.html
+++ b/tuneme/templates/core/article_page.html
@@ -88,8 +88,8 @@
       {% endfor %}
   {% if comment_count > 5 %}
     <div class="pagination">
-    <a href="{% url 'more-comments' self.pk %}">{% trans "view more comments" %}</a>
-  </div>
+      <a href="{% url 'more-comments' self.pk %}">{% trans "view more comments" %}</a>
+    </div>
   {% endif %}
 </div>
 {% endif %}

--- a/tuneme/templates/core/article_page.html
+++ b/tuneme/templates/core/article_page.html
@@ -81,10 +81,16 @@
 
 </div>
 <div id="comments-list">
-{% get_molo_comments for self as comment_list %}
-{% for node in comment_list|slice:":5" %}
-  {% include "comments/comment.html" %}
-{% endfor %}
+  {% get_comment_count for self as comment_count %}
+    {% get_molo_comments for self as comment_list %}
+      {% for node in comment_list %}
+        {% include "comments/comment.html" %}
+      {% endfor %}
+  {% if comment_count > 5 %}
+    <div class="pagination">
+    <a href="{% url 'more-comments' self.pk %}">{% trans "view more comments" %}</a>
+  </div>
+  {% endif %}
 </div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Each article that has more than the max number (currently 5) of comments should have a ‘View more comments’ at the bottom of the page that links to a paginated view of all comments.
