### PR TITLE
Configure flake8 to ignore settings files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
-exclude = ve,docs,tuneme/*/migrations/*,polls/migrations/*,test_settings.py,tuneme/settings/*.py,docker/settings.py
+ignore = F405
+exclude = ve,docs,tuneme/*/migrations/*,polls/migrations/*
 
 [pytest]
 addopts = --verbose --ds=test_settings --nomigrations --cov=tuneme --cov=polls --cov-report=term -s --ignore=ve

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [flake8]
-exclude = ve,docs,tuneme/*/migrations/*,polls/migrations/*
-ignore = F403
+exclude = ve,docs,tuneme/*/migrations/*,polls/migrations/*,test_settings.py,tuneme/settings/*.py,docker/settings.py
 
 [pytest]
 addopts = --verbose --ds=test_settings --nomigrations --cov=tuneme --cov=polls --cov-report=term -s --ignore=ve

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,4 +1,4 @@
-from tuneme.settings import *
+from tuneme.settings import *  # noqa
 
 DATABASES = {
     'default': {

--- a/tuneme/settings/__init__.py
+++ b/tuneme/settings/__init__.py
@@ -1,1 +1,1 @@
-from .dev import *
+from .dev import *  # noqa

--- a/tuneme/settings/dev.py
+++ b/tuneme/settings/dev.py
@@ -1,4 +1,4 @@
-from .base import *
+from .base import *  # noqa
 
 
 DEBUG = True
@@ -8,11 +8,11 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 
 try:
-    from .local import *
+    from .local import *  # noqa
 except ImportError:
     pass
 
 try:
-    from secrets import *
+    from secrets import *  # noqa
 except ImportError:
     pass

--- a/tuneme/settings/production.py
+++ b/tuneme/settings/production.py
@@ -1,5 +1,5 @@
 import os
-from .base import *
+from .base import *  # noqa
 
 
 # Disable debug mode
@@ -63,11 +63,11 @@ GOOGLE_PLACES_API_SERVER_KEY = os.environ.get(
 
 
 try:
-    from .local import *
+    from .local import *  # noqa
 except ImportError:
     pass
 
 try:
-    from secrets import *
+    from secrets import *  # noqa
 except ImportError:
     pass


### PR DESCRIPTION
Because `import *`s are useful for settings files, but we shouldn't use them anywhere else.
