### PR TITLE
return empty search

### DIFF
--- a/tuneme/views.py
+++ b/tuneme/views.py
@@ -13,7 +13,7 @@ def search(request, results_per_page=10):
     page = request.GET.get('p', 1)
     locale = get_locale_code(get_language_from_request(request))
 
-    if search_query:
+    if search_query and search_query.strip():
         results = ArticlePage.objects.filter(
             languages__language__locale=locale
         ).values_list('pk', flat=True)


### PR DESCRIPTION
Search containing only a "space" should return an empty results page, not error page...

@Mitso Please review

**Before**
![screen shot 2016-09-12 at 12 46 37 pm](https://cloud.githubusercontent.com/assets/9653693/18433304/10c57530-78e7-11e6-91b6-236defe236df.png)

**After**
![screen shot 2016-09-12 at 12 46 51 pm](https://cloud.githubusercontent.com/assets/9653693/18433308/17daac6e-78e7-11e6-8360-53c645c6c7ad.png)
