### PR TITLE
Docker: new switch for the celery worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM praekeltfoundation/molo-bootstrap:4.3.2-onbuild
 
 ENV DJANGO_SETTINGS_MODULE=tuneme.settings.docker \
     CELERY_APP=tuneme \
+    CELERY_WORKER=1 \
     CELERY_BEAT=1
 
 RUN LANGUAGE_CODE=en django-admin compilemessages && \


### PR DESCRIPTION
This is going to be needed once praekeltfoundation/django-bootstrap#39 is merged, but won't have any effect yet.