### PR TITLE
Add tagged docker image builds for TuneMe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,14 @@ jobs:
         - pip install docker-ci-deploy==0.3.0
         - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
       deploy:
-        provider: script
-        script: dcd --version "$(git rev-parse --short HEAD)" --version-latest "$IMAGE_NAME"
-        on:
-          branch: develop
+        - provider: script
+          script: dcd --version "$(git rev-parse --short HEAD)" --version-latest "$IMAGE_NAME"
+          on:
+            branch: develop
+        - provider: script
+          script: dcd --tag "$TRAVIS_TAG" -- "$IMAGE_NAME"
+          on:
+            tags: true
 
       # Built steps inherited from the default stage that we don't want
       before_install: ignore


### PR DESCRIPTION
This change to the `travis.yml` file creates an additional command for Travis.
If there is a tag attached to a build, it will automatically create an Docker Image, with the same name as the tag, and then push that Image to the associated account in Docker Hub.
In this case it will be https://hub.docker.com/r/praekeltfoundation/molo-tuneme/tags/