### PR TITLE
Make migration work for sqlite

### DIFF
--- a/tuneme/migrations/0004_delete_polls_index_page.py
+++ b/tuneme/migrations/0004_delete_polls_index_page.py
@@ -41,7 +41,7 @@ def delete_polls_index_page(apps, schema_editor):
 def remove_tables_from_postgres(apps, schema_editor):
     db_type = schema_editor.connection.vendor
 
-    if ((db_type == 'postgres') or (db_type == 'postgresql')):
+    if db_type == 'postgres' or db_type == 'postgresql':
         migrations.RunSQL("DELETE FROM polls_choice_choice_votes;"),
         migrations.RunSQL("DELETE FROM polls_choicevote_choice;"),
         migrations.RunSQL("DELETE FROM polls_choicevote;"),

--- a/tuneme/migrations/0004_delete_polls_index_page.py
+++ b/tuneme/migrations/0004_delete_polls_index_page.py
@@ -38,12 +38,10 @@ def delete_polls_index_page(apps, schema_editor):
         ct_pollsindexpage.delete()
 
 
-class Migration(migrations.Migration):
-    dependencies = [
-        ('tuneme', '0003_move_pages_to_index_pages'),
-    ]
+def remove_tables_from_postgres(apps, schema_editor):
+    db_type = schema_editor.connection.vendor
 
-    operations = [
+    if ((db_type == 'postgres') or (db_type == 'postgresql')):
         migrations.RunSQL("DELETE FROM polls_choice_choice_votes;"),
         migrations.RunSQL("DELETE FROM polls_choicevote_choice;"),
         migrations.RunSQL("DELETE FROM polls_choicevote;"),
@@ -52,5 +50,14 @@ class Migration(migrations.Migration):
         migrations.RunSQL("DELETE FROM polls_freetextquestion;"),
         migrations.RunSQL("DELETE FROM polls_question;"),
         migrations.RunSQL("DELETE FROM polls_pollsindexpage;"),
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('tuneme', '0003_move_pages_to_index_pages'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_tables_from_postgres),
         migrations.RunPython(delete_polls_index_page),
     ]


### PR DESCRIPTION
Our migration worked for QA and Production databases, but when running on SQLite dbs, threw the following error:
```
  Applying tuneme.0004_delete_polls_index_page...Traceback (most recent call last):
  File "./manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
    utility.execute()
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/core/management/__init__.py", line 345, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/core/management/base.py", line 348, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/core/management/base.py", line 399, in execute
    output = self.handle(*args, **options)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 200, in handle
    executor.migrate(targets, plan, fake=fake, fake_initial=fake_initial)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/db/migrations/executor.py", line 92, in migrate
    self._migrate_all_forwards(plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/db/migrations/executor.py", line 121, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/db/migrations/executor.py", line 198, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/db/migrations/migration.py", line 123, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/db/migrations/operations/special.py", line 102, in database_forwards
    self._run_sql(schema_editor, self.sql)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/db/migrations/operations/special.py", line 125, in _run_sql
    statements = schema_editor.connection.ops.prepare_sql_script(sqls)
  File "/Users/someuser/.virtualenvs/tuneme/lib/python2.7/site-packages/django/db/backends/base/operations.py", line 276, in prepare_sql_script
    "sqlparse is required if you don't split your SQL "
django.core.exceptions.ImproperlyConfigured: sqlparse is required if you don't split your SQL statements manually.
Raven is not configured (logging is disabled). Please see the documentation for more information.
```

Solution: only run the SQL commands when the DB is postgres.
Inspired by https://stackoverflow.com/questions/32384547/django-migration-runsql-conditional-on-database-type